### PR TITLE
Update README.rst

### DIFF
--- a/wpiformat/README.rst
+++ b/wpiformat/README.rst
@@ -16,7 +16,7 @@ Installation
 
 On Windows, execute::
 
-    py -m pip install wpiformat
+    python -m pip install wpiformat
 
 On Linux/OSX, execute::
 


### PR DESCRIPTION
fixes typo in installation instructions: change py to python